### PR TITLE
Update `halaxa/json-machine` dependency to `^0.8|^1.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
               run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
             - name: Upload coverage
+              if: github.repository_owner == 'cerbero90'
               run: |
                 wget https://scrutinizer-ci.com/ocular.phar
                 php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## NEXT - YYYY-MM-DD
 
 ### Added
-- Nothing
+- Support for `halaxa/json-machine: ^0.8|^1.0` 
 
 ### Deprecated
 - Nothing
@@ -16,7 +16,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Nothing
 
 ### Removed
-- Nothing
+- Support for `halaxa/json-machine: ^0.7`
 
 ### Security
 - Nothing

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }],
     "require": {
         "php": "^7.2||^8.0",
-        "halaxa/json-machine": "^0.7",
+        "halaxa/json-machine": "^0.8|^1.0",
         "illuminate/support": ">=6.0"
     },
     "suggest": {

--- a/src/Handlers/Filename.php
+++ b/src/Handlers/Filename.php
@@ -3,7 +3,7 @@
 namespace Cerbero\LazyJson\Handlers;
 
 use Cerbero\LazyJson\Concerns\JsonPointerAware;
-use JsonMachine\JsonMachine;
+use JsonMachine\Items;
 use Traversable;
 
 /**
@@ -34,6 +34,6 @@ class Filename implements Handler
      */
     public function handle($source, string $path): Traversable
     {
-        return JsonMachine::fromFile($source, $this->toJsonPointer($path));
+        return Items::fromFile($source, ['pointer' => $this->toJsonPointer($path)]);
     }
 }

--- a/src/Handlers/IterableSource.php
+++ b/src/Handlers/IterableSource.php
@@ -3,7 +3,7 @@
 namespace Cerbero\LazyJson\Handlers;
 
 use Cerbero\LazyJson\Concerns\JsonPointerAware;
-use JsonMachine\JsonMachine;
+use JsonMachine\Items;
 use Traversable;
 
 /**
@@ -34,6 +34,6 @@ class IterableSource implements Handler
      */
     public function handle($source, string $path): Traversable
     {
-        return JsonMachine::fromIterable($source, $this->toJsonPointer($path));
+        return Items::fromIterable($source, ['pointer' => $this->toJsonPointer($path)]);
     }
 }

--- a/src/Handlers/JsonString.php
+++ b/src/Handlers/JsonString.php
@@ -4,7 +4,7 @@ namespace Cerbero\LazyJson\Handlers;
 
 use Cerbero\LazyJson\Concerns\EndpointAware;
 use Cerbero\LazyJson\Concerns\JsonPointerAware;
-use JsonMachine\JsonMachine;
+use JsonMachine\Items;
 use Traversable;
 
 /**
@@ -36,6 +36,6 @@ class JsonString implements Handler
      */
     public function handle($source, string $path): Traversable
     {
-        return JsonMachine::fromString($source, $this->toJsonPointer($path));
+        return Items::fromString($source, ['pointer' => $this->toJsonPointer($path)]);
     }
 }

--- a/src/Handlers/Resource.php
+++ b/src/Handlers/Resource.php
@@ -3,7 +3,7 @@
 namespace Cerbero\LazyJson\Handlers;
 
 use Cerbero\LazyJson\Concerns\JsonPointerAware;
-use JsonMachine\JsonMachine;
+use JsonMachine\Items;
 use Traversable;
 
 /**
@@ -34,6 +34,6 @@ class Resource implements Handler
      */
     public function handle($source, string $path): Traversable
     {
-        return JsonMachine::fromStream($source, $this->toJsonPointer($path));
+        return Items::fromStream($source, ['pointer' => $this->toJsonPointer($path)]);
     }
 }

--- a/tests/Handlers/EndpointTest.php
+++ b/tests/Handlers/EndpointTest.php
@@ -6,7 +6,7 @@ use Cerbero\LazyJson\Exceptions\LazyJsonException;
 use Cerbero\LazyJson\Handlers\Endpoint;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response as Psr7Response;
-use JsonMachine\JsonMachine;
+use JsonMachine\Items;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -54,7 +54,7 @@ class EndpointTest extends TestCase
 
         $handled = (new Endpoint())->handle('https://endpoint.test', '');
 
-        $this->assertInstanceOf(JsonMachine::class, $handled);
+        $this->assertInstanceOf(Items::class, $handled);
 
         foreach ($handled as $key => $value) {
             $this->assertSame('end', $key);
@@ -73,7 +73,7 @@ class EndpointTest extends TestCase
 
         $handled = (new Endpoint())->handle('https://endpoint.test', 'foo.bar');
 
-        $this->assertInstanceOf(JsonMachine::class, $handled);
+        $this->assertInstanceOf(Items::class, $handled);
 
         foreach ($handled as $key => $value) {
             $this->assertSame('bar', $key);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes support for the relatively old 0.7.* releases of `halaxa/json-machine` and adds support for 0.8.* and 1.*

## Motivation and context

`composer outdated` shows `halaxa/json-machine` as an outdated transitive dependency in some of my projects (although it works just fine with the 0.7.* releases).

## How has this been tested?

The 0.8.* releases should be covered by the `--prefer-lowest` flags, 1.* with the other matrix tests.

I tried adding PHP 8.1 and Laravel 9 to the test matrix, but this resulted in ~140 runs and didn't feel right 😅 

## Types of changes

I don't think this is a breaking change - if a project or one of its other dependencies requires `"halaxa/json-machine": "^0.7"`, it will just stay on `lazy-json` 1.1.1.

The change in the GitHub action just prevents forks like mine from trying to upload the code coverage reports to Scrutinizer. I hope it's ok that I included the change in this PR, otherwise I'll revert it and create a new PR with the change.

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have adapted the tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
